### PR TITLE
[TPS-01] TalentFactory way to create talent tokens

### DIFF
--- a/contracts/TalentFactory.sol
+++ b/contracts/TalentFactory.sol
@@ -116,11 +116,13 @@ contract TalentFactory is
         string memory _name,
         string memory _symbol
     ) public returns (address) {
-        require(whitelist[_talent] == true, "address needs to be whitelisted");
-        require(msg.sender == minter || msg.sender == _talent, "talent must be owner");
+        require(whitelist[_talent], "address needs to be whitelisted");
+        require(msg.sender == minter || msg.sender == _talent, "talent must be minter or owner");
         require(talentsToTokens[_talent] == address(0x0), "talent already has talent token");
         require(!isSymbol(_symbol), "symbol already exists");
         require(_isMinterSet(), "minter not yet set");
+
+        whitelist[_talent] = false;
 
         BeaconProxy proxy = new BeaconProxy(
             implementationBeacon,
@@ -150,7 +152,6 @@ contract TalentFactory is
         tokensToTalents[token] = _talent;
         /// Added for V2
         talentsToTokens[_talent] = token;
-        whitelist[_talent] = false;
 
         emit TalentCreated(_talent, token);
 

--- a/contracts/TalentFactory.sol
+++ b/contracts/TalentFactory.sol
@@ -102,6 +102,8 @@ contract TalentFactory is
         string memory _name,
         string memory _symbol
     ) public returns (address) {
+        require(msg.sender == minter || msg.sender == _talent, "talent must be owner");
+        require(talentsToTokens[_talent] == address(0x0), "talent already has talent token");
         require(!isSymbol(_symbol), "symbol already exists");
         require(_isMinterSet(), "minter not yet set");
 

--- a/contracts/season3/TalentFactoryV3.sol
+++ b/contracts/season3/TalentFactoryV3.sol
@@ -18,7 +18,7 @@ interface ITalentFactoryV3 {
 }
 
 contract TalentFactoryV3 is TalentFactoryV2, ITalentFactoryV3 {
-    function version() public pure virtual returns (uint256) {
+    function version() public pure virtual override(TalentFactoryV2) returns (uint256) {
         return 3;
     }
 

--- a/contracts/season3/TalentFactoryV3.sol
+++ b/contracts/season3/TalentFactoryV3.sol
@@ -6,7 +6,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "hardhat/console.sol";
 
 import {ITalentToken} from "../TalentToken.sol";
-import {TalentFactory} from "../TalentFactory.sol";
+import {TalentFactoryV2} from "../TalentFactoryV2.sol";
 import {IVirtualTAL} from "./VirtualTAL.sol";
 
 interface ITalentFactoryV3 {
@@ -17,7 +17,7 @@ interface ITalentFactoryV3 {
     function hasTalentToken(address addr) external view returns (bool);
 }
 
-contract TalentFactoryV3 is TalentFactory, ITalentFactoryV3 {
+contract TalentFactoryV3 is TalentFactoryV2, ITalentFactoryV3 {
     function version() public pure virtual returns (uint256) {
         return 3;
     }

--- a/test/contracts/Staking.ts
+++ b/test/contracts/Staking.ts
@@ -179,6 +179,10 @@ describe("Staking", () => {
       staking = await builder();
 
       await factory.setMinter(staking.address);
+      await factory.setWhitelister(minter.address);
+
+      await factory.connect(minter).whitelistAddress(talent1.address);
+      await factory.connect(minter).whitelistAddress(talent2.address);
 
       talentToken1 = await deployTalentToken(factory, minter, talent1, "Miguel Palhas", "NAPS");
       talentToken2 = await deployTalentToken(factory, minter, talent2, "Francisco Leal", "LEAL");

--- a/test/contracts/TalentFactory.ts
+++ b/test/contracts/TalentFactory.ts
@@ -124,7 +124,7 @@ describe("TalentFactory", () => {
       it("cannot create talent token for other talent", async () => {
         const action = factory.connect(attacker).createTalent(talent1.address, "Miguel Palhas", "NAPЅ");
 
-        await expect(action).to.be.revertedWith("cannot create a talent token for another talent");
+        await expect(action).to.be.revertedWith("talent must be minter or owner");
       });
 
       it("cannot create when talent already has talent token", async () => {

--- a/test/contracts/TalentTokenV2.ts
+++ b/test/contracts/TalentTokenV2.ts
@@ -5,7 +5,7 @@ import { solidity } from "ethereum-waffle";
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import type { ContractFactory } from "ethers";
 
-import type { TalentFactory, TalentFactoryV2, TalentToken, TalentTokenV2 } from "../../typechain-types";
+import type { TalentFactory, TalentToken } from "../../typechain-types";
 import {
   TalentToken__factory,
   TalentTokenV2__factory,
@@ -15,7 +15,6 @@ import {
 
 import TalentTokenV2Artifact from "../../artifacts/contracts/test/TalentTokenV2.sol/TalentTokenV2.json";
 
-import { ERC165, Artifacts } from "../shared";
 import { findEvent } from "../shared/utils";
 
 chai.use(solidity);
@@ -24,7 +23,7 @@ const { expect } = chai;
 const { parseUnits } = ethers.utils;
 const { deployContract } = waffle;
 
-describe("TalentFactory", () => {
+describe("TalentFactoryV2", () => {
   let creator: SignerWithAddress;
   let minter: SignerWithAddress;
   let talent1: SignerWithAddress;
@@ -75,7 +74,7 @@ describe("TalentFactory", () => {
       // state is kept
       // expect(napsv2.balanceOf(creator.address)).to.equal(parseUnits("1.42"));
 
-      const tx = await factory.connect(minter).createTalent(talent1.address, "Francisco Leal", "LEAL");
+      const tx = await factory.connect(minter).createTalent(talent2.address, "Francisco Leal", "LEAL");
       const event = await findEvent(tx, "TalentCreated");
       const leal = TalentTokenV2__factory.connect(event?.args?.token, creator);
 
@@ -108,7 +107,7 @@ describe("TalentFactory", () => {
 
       await beacon.upgradeTo(talentTokenV2.address);
       const napsv2 = TalentTokenV2__factory.connect(naps.address, creator);
-      const defaultAdminRole = await napsv2.DEFAULT_ADMIN_ROLE()
+      const defaultAdminRole = await napsv2.DEFAULT_ADMIN_ROLE();
 
       await expect(napsv2.connect(talent1).removeMinter(minter.address)).to.be.revertedWith(
         `AccessControl: account ${talent1.address.toLowerCase()} is missing role ${defaultAdminRole}`

--- a/test/contracts/TalentTokenV2.ts
+++ b/test/contracts/TalentTokenV2.ts
@@ -23,7 +23,7 @@ const { expect } = chai;
 const { parseUnits } = ethers.utils;
 const { deployContract } = waffle;
 
-describe("TalentFactoryV2", () => {
+describe("TalentTokenV2", () => {
   let creator: SignerWithAddress;
   let minter: SignerWithAddress;
   let talent1: SignerWithAddress;
@@ -50,6 +50,10 @@ describe("TalentFactoryV2", () => {
       factory = (await upgrades.deployProxy(TalentFactoryFactory, [])) as TalentFactory;
 
       await factory.setMinter(minter.address);
+      await factory.setWhitelister(minter.address);
+
+      await factory.connect(minter).whitelistAddress(talent1.address);
+      await factory.connect(minter).whitelistAddress(talent2.address);
 
       const tx = await factory.connect(minter).createTalent(talent1.address, "Miguel Palhas", "NAPS");
       const event = await findEvent(tx, "TalentCreated");

--- a/test/contracts/season3/StakingV3.ts
+++ b/test/contracts/season3/StakingV3.ts
@@ -212,6 +212,10 @@ describe("StakingV3", () => {
       stakingV3 = await builder();
 
       await factory.setMinter(stakingV3.address);
+      await factory.setWhitelister(minter.address);
+
+      await factory.connect(minter).whitelistAddress(talent1.address);
+      await factory.connect(minter).whitelistAddress(talent2.address);
 
       talentToken1 = await deployTalentToken(factory, minter, talent1, "Miguel Palhas", "NAPS");
       talentToken2 = await deployTalentToken(factory, minter, talent2, "Francisco Leal", "LEAL");

--- a/test/integration/StakingFlow.ts
+++ b/test/integration/StakingFlow.ts
@@ -15,7 +15,7 @@ const { expect } = chai;
 const { parseUnits } = ethers.utils;
 const { deployContract } = waffle;
 
-describe("Staking", () => {
+describe("StakingFlow", () => {
   let owner: SignerWithAddress;
   let minter: SignerWithAddress;
   let talent1: SignerWithAddress;
@@ -75,7 +75,7 @@ describe("Staking", () => {
     // deploy talent tokens
     talentToken1 = await deployTalentToken(factory, minter, talent1, "Miguel Palhas", "NAPS");
     talentToken2 = await deployTalentToken(factory, minter, talent2, "Francisco Leal", "LEAL");
-    talentToken3 = await deployTalentToken(factory, minter, talent2, "Andreas Vilela", "AVIL");
+    talentToken3 = await deployTalentToken(factory, minter, talent3, "Andreas Vilela", "AVIL");
 
     // fund investors
     await stable.connect(owner).transfer(investor1.address, parseUnits("100000"));

--- a/test/integration/StakingFlow.ts
+++ b/test/integration/StakingFlow.ts
@@ -71,6 +71,11 @@ describe("StakingFlow", () => {
     ])) as Staking;
 
     await factory.setMinter(staking.address);
+    await factory.setWhitelister(minter.address);
+
+    await factory.connect(minter).whitelistAddress(talent1.address);
+    await factory.connect(minter).whitelistAddress(talent2.address);
+    await factory.connect(minter).whitelistAddress(talent3.address);
 
     // deploy talent tokens
     talentToken1 = await deployTalentToken(factory, minter, talent1, "Miguel Palhas", "NAPS");

--- a/test/integration/StakingMigration.ts
+++ b/test/integration/StakingMigration.ts
@@ -88,7 +88,7 @@ describe("StakingMigration", () => {
     // deploy talent tokens
     talentToken1 = await deployTalentToken(factory, minter, talent1, "Miguel Palhas", "NAPS");
     talentToken2 = await deployTalentToken(factory, minter, talent2, "Francisco Leal", "LEAL");
-    talentToken3 = await deployTalentToken(factory, minter, talent2, "Andreas Vilela", "AVIL");
+    talentToken3 = await deployTalentToken(factory, minter, talent3, "Andreas Vilela", "AVIL");
 
     // fund investors
     await stable.connect(owner).transfer(investor1.address, parseUnits("100000"));

--- a/test/integration/StakingMigration.ts
+++ b/test/integration/StakingMigration.ts
@@ -84,6 +84,11 @@ describe("StakingMigration", () => {
     await staking.deployed();
 
     await factory.setMinter(staking.address);
+    await factory.setWhitelister(minter.address);
+
+    await factory.connect(minter).whitelistAddress(talent1.address);
+    await factory.connect(minter).whitelistAddress(talent2.address);
+    await factory.connect(minter).whitelistAddress(talent3.address);
 
     // deploy talent tokens
     talentToken1 = await deployTalentToken(factory, minter, talent1, "Miguel Palhas", "NAPS");

--- a/test/integration/Upgrades.ts
+++ b/test/integration/Upgrades.ts
@@ -46,6 +46,10 @@ describe("TalentFactory", () => {
       factory = (await upgrades.deployProxy(TalentFactoryFactory, [])) as TalentFactory;
 
       await factory.setMinter(minter.address);
+      await factory.setWhitelister(minter.address);
+
+      await factory.connect(minter).whitelistAddress(talent1.address);
+      await factory.connect(minter).whitelistAddress(talent2.address);
 
       const tx = await factory.connect(minter).createTalent(talent1.address, "Miguel Palhas", "NAPS");
       const event = await findEvent(tx, "TalentCreated");

--- a/test/integration/Upgrades.ts
+++ b/test/integration/Upgrades.ts
@@ -72,7 +72,7 @@ describe("TalentFactory", () => {
       // state is kept
       // expect(napsv2.balanceOf(creator.address)).to.equal(parseUnits("1.42"));
 
-      const tx = await factory.connect(minter).createTalent(talent1.address, "Francisco Leal", "LEAL");
+      const tx = await factory.connect(minter).createTalent(talent2.address, "Francisco Leal", "LEAL");
       const event = await findEvent(tx, "TalentCreated");
       const leal = TalentTokenV2__factory.connect(event?.args?.token, creator);
 

--- a/test/shared/utils.ts
+++ b/test/shared/utils.ts
@@ -22,7 +22,7 @@ export async function deployTalentToken(
   name: string,
   symbol: string
 ): Promise<TalentToken> {
-  const tx = await factory.connect(minter).createTalent(owner.address, name, symbol);
+  const tx = await factory.connect(owner).createTalent(owner.address, name, symbol);
   const event = await findEvent(tx, "TalentCreated");
 
   const address = event?.args?.token;


### PR DESCRIPTION
We want to fix a couple of issues with this PR:
- Only the own user or the minter can create a talent token
- Only one token allowed per address
- Only a whitelisted address can create a talent token, since we mint 2000 talent tokens and give them to the user