### PR TITLE
[TPS-02] Add __gap to base and possible future base contracts

### DIFF
--- a/contracts/TalentFactory.sol
+++ b/contracts/TalentFactory.sol
@@ -71,6 +71,9 @@ contract TalentFactory is
     /// implementation template to clone
     address public implementationBeacon;
 
+    /// https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps
+    uint256[49] __gap;
+
     event TalentCreated(address indexed talent, address indexed token);
 
     function initialize() public virtual initializer {

--- a/contracts/TalentFactory.sol
+++ b/contracts/TalentFactory.sol
@@ -71,9 +71,6 @@ contract TalentFactory is
     /// implementation template to clone
     address public implementationBeacon;
 
-    /// https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps
-    uint256[49] __gap;
-
     event TalentCreated(address indexed talent, address indexed token);
 
     function initialize() public virtual initializer {
@@ -179,4 +176,7 @@ contract TalentFactory is
     function _isMinterSet() private view returns (bool) {
         return minter != address(0x0);
     }
+
+    /// https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps
+    uint256[49] __gap;
 }

--- a/contracts/staking_helpers/StableThenToken.sol
+++ b/contracts/staking_helpers/StableThenToken.sol
@@ -27,9 +27,6 @@ abstract contract StableThenToken is Initializable, AccessControlEnumerableUpgra
     /// the token to stake
     address public token;
 
-    /// https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps
-    uint256[49] __gap;
-
     /// @param _stableCoin The USD-pegged stable-coin contract to use
     function __StableThenToken_init(address _stableCoin) public virtual initializer {
         // USDT does not implement ERC165, so we can't do much more than this
@@ -74,4 +71,7 @@ abstract contract StableThenToken is Initializable, AccessControlEnumerableUpgra
     function memcmp(bytes memory a, bytes memory b) private pure returns (bool) {
         return (a.length == b.length) && (keccak256(a) == keccak256(b));
     }
+
+    /// https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps
+    uint256[49] __gap;
 }

--- a/contracts/staking_helpers/StableThenToken.sol
+++ b/contracts/staking_helpers/StableThenToken.sol
@@ -27,6 +27,9 @@ abstract contract StableThenToken is Initializable, AccessControlEnumerableUpgra
     /// the token to stake
     address public token;
 
+    /// https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps
+    uint256[49] __gap;
+
     /// @param _stableCoin The USD-pegged stable-coin contract to use
     function __StableThenToken_init(address _stableCoin) public virtual initializer {
         // USDT does not implement ERC165, so we can't do much more than this

--- a/contracts/tokens/ERC1363Upgradeable.sol
+++ b/contracts/tokens/ERC1363Upgradeable.sol
@@ -26,9 +26,6 @@ abstract contract ERC1363Upgradeable is
 {
     using AddressUpgradeable for address;
 
-    /// https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps
-    uint256[49] __gap;
-
     function __ERC1363_init(string memory _name, string memory _symbol) internal initializer {
         __Context_init_unchained();
         __ERC165_init_unchained();
@@ -179,4 +176,7 @@ abstract contract ERC1363Upgradeable is
         bytes4 retval = IERC1363SpenderUpgradeable(spender).onApprovalReceived(_msgSender(), amount, data);
         return (retval == IERC1363SpenderUpgradeable(spender).onApprovalReceived.selector);
     }
+
+    /// https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps
+    uint256[49] __gap;
 }

--- a/contracts/tokens/ERC1363Upgradeable.sol
+++ b/contracts/tokens/ERC1363Upgradeable.sol
@@ -26,6 +26,9 @@ abstract contract ERC1363Upgradeable is
 {
     using AddressUpgradeable for address;
 
+    /// https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps
+    uint256[49] __gap;
+
     function __ERC1363_init(string memory _name, string memory _symbol) internal initializer {
         __Context_init_unchained();
         __ERC165_init_unchained();


### PR DESCRIPTION
When designing upgradeable contracts, it is necessary to reserve additional memory space between the upgraded contracts and the new contracts to be upgraded. With this PR we add an array called __gap to base contracts 