### PR TITLE
Upgrade GitHub Actions to Latest Major Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,11 @@ jobs:
       PRIVATE_KEY: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
 
@@ -28,7 +31,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
To address the deprecation notice mentioned in issue #107 regarding `actions/cache@v2`, I have updated the GitHub Actions workflow.

This pull request includes updates to the workflow configuration in the `.github/workflows/test.yml` file. The primary focus is on upgrading the versions of the actions used in the workflow.

**Workflow Configuration Updates:**

- Updated the `actions/checkout` action from version `v2` to `v4`.
  - [actions/checkout Release Page](https://github.com/actions/checkout/releases)
- Updated the `actions/setup-node` action from version `v2` to `v4`.
  - [actions/setup-node Release Page](https://github.com/actions/setup-node/releases)
- Updated the `actions/cache` action from version `v2` to `v4`.
  - [actions/cache Release Page](https://github.com/actions/cache/releases)

**Reasoning:**

I chose to specify only the major version (e.g., `v4`) instead of exact minor and patch versions like `v4.1.2`. This approach allows the workflow to automatically receive backward-compatible updates, including security patches and minor improvements, without the need to frequently update the workflow file.

For your reference, here are the latest releases of each action:

- [actions/checkout v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)
- [actions/setup-node v4.1.0](https://github.com/actions/setup-node/releases/tag/v4.1.0)
- [actions/cache v4.1.2](https://github.com/actions/cache/releases/tag/v4.1.2)

Please let me know if you'd prefer to pin to specific versions or have any questions.