### PR TITLE
Fix Incorrect Argument Format in getProof Method

### DIFF
--- a/scripts/talent/deployTGEUnlocks.ts
+++ b/scripts/talent/deployTGEUnlocks.ts
@@ -45,7 +45,7 @@ async function main() {
   console.log(`TGE Unlock distribution deployed at ${tgeUnlockDistribution.address}`);
   const proofList = allResults.map(({ wallet, total }) => {
     const value = ethers.utils.parseEther(total);
-    const proof = merkleTree.getProof([wallet.toLowerCase(), value]);
+    const proof = merkleTree.getProof([wallet.toLowerCase(), value.toString()]);
     return {
       wallet,
       value,


### PR DESCRIPTION
#### Problem
The `getProof` method in the `@openzeppelin/merkle-tree` library expects input data in the format consistent with the leaf structure of the Merkle Tree. In the current implementation, the method is called with an array containing the address and value directly:

```typescript
const proof = merkleTree.getProof([wallet.toLowerCase(), value]);
```

However, this results in an error because the values in the tree are formatted as strings (e.g., `"uint256"`), while `value` is passed as a `bigint`. This mismatch leads to invalid or empty proofs, making them unusable for verification.

#### Solution
To ensure compatibility with the tree's structure, the `value` must be converted to a string before being passed to the `getProof` method. This aligns the input format with the expected `[address, uint256]` structure of the Merkle Tree leaves.

**Fixed Code:**
```typescript
const proof = merkleTree.getProof([wallet.toLowerCase(), value.toString()]);
```

#### Importance of Fix
1. **Proof Generation**: Without this fix, the proofs generated are invalid or empty, as the `getProof` method fails to match the input with the tree's leaves.
2. **Smart Contract Compatibility**: The Merkle proofs are crucial for verifying data on-chain. Incorrect proofs result in failed verification, breaking the intended functionality.
3. **Data Consistency**: Ensuring consistent formatting between the tree's structure and the proof input guarantees reliability and correctness.

#### Additional Notes
- The issue stems from a mismatch in data types: `bigint` vs. `string`. By explicitly converting the `value` to a string, we ensure proper functionality.
- This fix impacts the generation of proofs and their subsequent usage, so it is critical for the successful deployment of the Merkle-based system.

---

By addressing this issue, we ensure that the generated proofs are valid and compatible with the Merkle Tree structure and on-chain verification requirements.