### PR TITLE
update deprecated set output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)


### PR DESCRIPTION
# Replace deprecated set-output command with GITHUB_OUTPUT

This pull request updates the GitHub Actions workflow configuration file `.github/workflows/test.yml` to replace the deprecated `set-output` command with the recommended `GITHUB_OUTPUT` environment file approach.

## Changes

The change updates the way the yarn cache directory path is set in the workflow:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L32-R32): 
  - Before: `echo "::set-output name=dir::$(yarn cache dir)"`
  - After: `echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT`

## Motivation

GitHub has announced the deprecation of the `set-output` workflow command. This PR updates our workflow to use the new recommended approach using the `GITHUB_OUTPUT` environment file, which will ensure our CI/CD pipeline continues to work reliably after the deprecation takes effect.

## Technical Details

The `GITHUB_OUTPUT` environment file is the new recommended way to set outputs in GitHub Actions. This approach:
- Is more secure and reliable
- Follows current GitHub Actions best practices
- Eliminates deprecation warnings in our workflow logs

## References

- Related Issue: fix https://github.com/talentprotocol/contracts/issues/108
- [GitHub Blog - Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)