### PR TITLE
fix: replace deprecated set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)


### PR DESCRIPTION
## Summary
Replace the deprecated `::set-output` command with the new `$GITHUB_OUTPUT` environment file approach.

## Changes
- Updated `.github/workflows/test.yml` line 34
- Changed from: `echo "::set-output name=dir::$(yarn cache dir)"`  
- Changed to: `echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT`

## Reference
- GitHub changelog: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Fixes #108