### PR TITLE
chore: remove deprecated hardhat-etherscan and add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Deployer private key (never commit the real key)
+PRIVATE_KEY=
+
+# RPC URLs
+BASE_SEPOLIA_RPC_URL=
+BASE_RPC_URL=
+CELO_RPC_URL=
+
+# Block explorer API keys (for contract verification)
+BASE_API_KEY=

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.10",
     "@nomicfoundation/hardhat-verify": "^2.0.14",
-    "@nomiclabs/hardhat-etherscan": "^3.1.7",
     "@types/chai": "^4.3.4",
     "@types/chai-as-promised": "^7.1.4",
     "@types/mocha": "^10.0.1",


### PR DESCRIPTION
## Summary
Removes an unused deprecated dependency and adds an `.env.example` file to improve developer onboarding.

## Changes

### Remove deprecated `@nomiclabs/hardhat-etherscan`
- This package is deprecated in favor of `@nomicfoundation/hardhat-verify` (already present in devDependencies)
- Not imported anywhere in the codebase — only `@nomicfoundation/hardhat-verify` is used in `hardhat.config.ts`

### Add `.env.example`
- Lists all required environment variables referenced in `hardhat.config.ts`
- Helps new contributors set up their local environment without guessing which variables are needed

## Context
Relates to #109 — the hardcoded keys issue has been resolved (config already uses `process.env`), but this PR further improves the setup experience by documenting the required variables.